### PR TITLE
Added convenience methods Rika.parse_content, Rika.parse_metadata, and R...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/version_tmp
 tmp
 
 .DS_Store
+projectFilesBackup/
+.idea/

--- a/lib/rika.rb
+++ b/lib/rika.rb
@@ -18,7 +18,23 @@ module Rika
   import org.apache.tika.language.LanguageIdentifier
   import java.io.FileInputStream
   import java.net.URL
-  
+
+  def self.parse_content_and_metadata(file_location, max_content_length = -1)
+    parser = Parser.new(file_location, max_content_length)
+    [parser.content, parser.metadata]
+  end
+
+  def self.parse_content(file_location, max_content_length = -1)
+    parser = Parser.new(file_location, max_content_length)
+    parser.content
+  end
+
+  def self.parse_metadata(file_location)
+    parser = Parser.new(file_location, 0)
+    parser.metadata
+  end
+
+
   class Parser
     
     def initialize(file_location, max_content_length = -1)

--- a/spec/rika_spec.rb
+++ b/spec/rika_spec.rb
@@ -21,6 +21,7 @@ describe Rika::Parser do
       :AccessLog => [], :Logger => WEBrick::Log::new("/dev/null", 7))  
       @server.start
     end
+    @sample_pdf_filespec = file_path("document.pdf")
   end
 
   after(:all) do
@@ -172,5 +173,21 @@ describe Rika::Parser do
       lang = Rika::Parser.new(file_path("en.txt"))
       lang.language_is_reasonably_certain? == true
     end
+  end
+
+  it "should return valid content using Rika.parse_content" do
+    content = Rika.parse_content(@sample_pdf_filespec)
+    (content.should be_a(String)) && (content.should_not be_empty)
+  end
+
+  it "should return valid metadata using Rika.parse_metadata" do
+    metadata = Rika.parse_metadata(@sample_pdf_filespec)
+    (metadata.should be_a(Hash)) && (metadata.should_not be_empty)
+  end
+
+  it "should return valid content and metadata using Rika.parse_content_and_metadata" do
+    content, metadata = Rika.parse_content_and_metadata(@sample_pdf_filespec)
+    (content.should be_a(String)) && (content.should_not be_empty) && \
+      (metadata.should be_a(Hash)) && (metadata.should_not be_empty)
   end
 end


### PR DESCRIPTION
...ika.parse_content_and_metadata for (what I think are) the most common use cases.

Richard, I've found that most of the time I only want the content or the content and the metadata, and thought these convenience methods might be useful for others as well.  What do you think?

If you want this change, I can add explanations of this to the README if you like.

I'll be doing a lightning talk on JRuby at BigRubyConf in Dallas, Texas this Thursday or Friday and I'm planning to show Rika. I was thinking it would be really cool to be able to parse a document in a single function call.

Cheers,
Keith
